### PR TITLE
Avoid memory leak on Linux in NSUUID

### DIFF
--- a/Sources/KituraSession/CookieManagement.swift
+++ b/Sources/KituraSession/CookieManagement.swift
@@ -80,7 +80,7 @@ internal class CookieManagement {
             newSession = false
         } else {
             // No Cookie
-            sessionId = NSUUID().uuidString
+            sessionId = UUID().uuidString
             newSession = true
         }
         return (sessionId, newSession)


### PR DESCRIPTION
Use UUID instead of NSUUID, as the latter leaks memory on Linux.
This resolves IBM-Swift/Kitura#972

I ran @carlbrown's KituraMiddlewareLeakSpike test with an additional plaintext route defined (for speed), using `valgrind --tool=massif` and then post-process the output with `ms_print massif.out.<pid> | swift-demangle > report.txt` to get the reports below.

With NSUUID, this leaked around 20mb of memory after 500,000 requests:
```
Command:            .build/release/HelloMiddleware
--------------------------------------------------------------------------------

    MB
43.26^                                                                       #
     |                                                                    @@@#
     |                                                                @@@@@@@#
     |                                                             @@@@@@@@@@#
     |                                                         @@@@@@@@@@@@@@#
     |                                                     @@@@@@@@@@@@@@@@@@#
     |                                                 :@@@@@@@@@@@@@@@@@@@@@#
     |                                             :::@@@@@@@@@@@@@@@@@@@@@@@#
     |                                          @@@:: @@@@@@@@@@@@@@@@@@@@@@@#
     |                                      @:@@@ @:: @@@@@@@@@@@@@@@@@@@@@@@#
     |                                   @@@@:@@@ @:: @@@@@@@@@@@@@@@@@@@@@@@#
     |                               :@@:@ @@:@@@ @:: @@@@@@@@@@@@@@@@@@@@@@@#
     |                           @@:::@@:@ @@:@@@ @:: @@@@@@@@@@@@@@@@@@@@@@@#
     |                        ::@@@:::@@:@ @@:@@@ @:: @@@@@@@@@@@@@@@@@@@@@@@#
     |                    :@@:::@@@:::@@:@ @@:@@@ @:: @@@@@@@@@@@@@@@@@@@@@@@#
     |                :@:@:@ :::@@@:::@@:@ @@:@@@ @:: @@@@@@@@@@@@@@@@@@@@@@@#
     |             :@::@:@:@ :::@@@:::@@:@ @@:@@@ @:: @@@@@@@@@@@@@@@@@@@@@@@#
     |        @:@@::@::@:@:@ :::@@@:::@@:@ @@:@@@ @:: @@@@@@@@@@@@@@@@@@@@@@@#
     |     :@@@:@ ::@::@:@:@ :::@@@:::@@:@ @@:@@@ @:: @@@@@@@@@@@@@@@@@@@@@@@#
     | :@:::@@@:@ ::@::@:@:@ :::@@@:::@@:@ @@:@@@ @:: @@@@@@@@@@@@@@@@@@@@@@@#
   0 +----------------------------------------------------------------------->Gi
     0                                                                   370.2

--------------------------------------------------------------------------------
  n        time(i)         total(B)   useful-heap(B) extra-heap(B)    stacks(B)
--------------------------------------------------------------------------------
 98 397,463,378,356       45,363,792       28,172,366    17,191,426            0
62.10% (28,172,366B) (heap allocation functions) malloc/new/new[], --alloc-fns, etc.
->59.86% (27,156,477B) 0x57590F4: swift_slowAlloc (in /home/djones6/.swiftenv/versions/3.0.2/usr/lib/swift/linux/libswiftCore.so)
| ->41.16% (18,672,568B) 0x5EAB6B8: Foundation.NSUUID.uuidString.getter : Swift.String (in /home/djones6/.swiftenv/versions/3.0.2/usr/lib/swift/linux/libFoundation.so)
| ->17.80% (8,074,624B) 0x5EAB38C: Foundation.NSUUID.__allocating_init () -> Foundation.NSUUID (in /home/djones6/.swiftenv/versions/3.0.2/usr/lib/swift/linux/libFoundation.so)
->01.73% (786,944B) 0x4085DC2: _dispatch_continuation_alloc_from_heap (in /home/djones6/.swiftenv/versions/3.0.2/usr/lib/swift/linux/libdispatch.so)
```
With UUID, there is no leak:
```
Command:            ./build_NSUUID_fix/release/HelloMiddleware
--------------------------------------------------------------------------------

    MB
1.749^                                                            #
     |       @@    @@ ::    ::                                  @@#      ::  :
     |   ::::@ @:::@ :: ::::: ::::::::::@:::::::::::::::::::::::@ #::::::: :@:
     |   ::::@ @: :@ :: : ::: : ::: :: :@:: ::: :: : : :: :: : :@ #:: :: : :@:
     | @@::::@ @: :@ :: : ::: : ::: :: :@:: ::: :: : : :: :: : :@ #:: :: : :@:
     | @ ::::@ @: :@ :: : ::: : ::: :: :@:: ::: :: : : :: :: : :@ #:: :: : :@:
     | @ ::::@ @: :@ :: : ::: : ::: :: :@:: ::: :: : : :: :: : :@ #:: :: : :@:
     | @ ::::@ @: :@ :: : ::: : ::: :: :@:: ::: :: : : :: :: : :@ #:: :: : :@:
     | @ ::::@ @: :@ :: : ::: : ::: :: :@:: ::: :: : : :: :: : :@ #:: :: : :@:
     | @ ::::@ @: :@ :: : ::: : ::: :: :@:: ::: :: : : :: :: : :@ #:: :: : :@:
     | @ ::::@ @: :@ :: : ::: : ::: :: :@:: ::: :: : : :: :: : :@ #:: :: : :@:
     | @ ::::@ @: :@ :: : ::: : ::: :: :@:: ::: :: : : :: :: : :@ #:: :: : :@:
     | @ ::::@ @: :@ :: : ::: : ::: :: :@:: ::: :: : : :: :: : :@ #:: :: : :@:
     | @ ::::@ @: :@ :: : ::: : ::: :: :@:: ::: :: : : :: :: : :@ #:: :: : :@:
     | @ ::::@ @: :@ :: : ::: : ::: :: :@:: ::: :: : : :: :: : :@ #:: :: : :@:
     | @ ::::@ @: :@ :: : ::: : ::: :: :@:: ::: :: : : :: :: : :@ #:: :: : :@:
     | @ ::::@ @: :@ :: : ::: : ::: :: :@:: ::: :: : : :: :: : :@ #:: :: : :@:
     | @ ::::@ @: :@ :: : ::: : ::: :: :@:: ::: :: : : :: :: : :@ #:: :: : :@:
     | @ ::::@ @: :@ :: : ::: : ::: :: :@:: ::: :: : : :: :: : :@ #:: :: : :@:
     | @ ::::@ @: :@ :: : ::: : ::: :: :@:: ::: :: : : :: :: : :@ #:: :: : :@:
   0 +----------------------------------------------------------------------->Gi
     0                                                                   357.5

--------------------------------------------------------------------------------
  n        time(i)         total(B)   useful-heap(B) extra-heap(B)    stacks(B)
--------------------------------------------------------------------------------
 48 376,812,068,667        1,721,384        1,476,236       245,148            0
85.76% (1,476,236B) (heap allocation functions) malloc/new/new[], --alloc-fns, etc.
->49.53% (852,608B) 0x4085DC2: _dispatch_continuation_alloc_from_heap (in /home/djones6/.swiftenv/versions/3.0.2/usr/lib/swift/linux/libdispatch.so)
->22.85% (393,303B) 0x57590F4: swift_slowAlloc (in /home/djones6/.swiftenv/versions/3.0.2/usr/lib/swift/linux/libswiftCore.so)
```