### PR TITLE
remove swiftJSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Packages
 .build
 build
 Package.resolved
+.DS_Store

--- a/Package.swift
+++ b/Package.swift
@@ -31,18 +31,17 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/IBM-Swift/Kitura.git", .upToNextMinor(from: "2.1.0")),
         .package(url: "https://github.com/IBM-Swift/BlueCryptor.git", .upToNextMinor(from: "0.8.0")),
-        .package(url: "https://github.com/IBM-Swift/SwiftyJSON.git", .upToNextMajor(from: "17.0.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "KituraSession",
-            dependencies: ["Kitura", "Cryptor", "SwiftyJSON"]
+            dependencies: ["Kitura", "Cryptor"]
         ),
         .testTarget(
             name: "KituraSessionTests",
-            dependencies: ["KituraSession", "SwiftyJSON"]
+            dependencies: ["KituraSession"]
         )
     ]
 )

--- a/Sources/KituraSession/SessionState.swift
+++ b/Sources/KituraSession/SessionState.swift
@@ -15,15 +15,8 @@
  **/
 
 import Foundation
-import SwiftyJSON
 
 // MARK SessionState
-
-#if os(Linux)
-    typealias SessionStateObjectType = Any
-#else
-    typealias SessionStateObjectType = AnyObject
-#endif
 
 /// A set of helper functions to manipulate session data.
 public class SessionState {
@@ -38,7 +31,7 @@ public class SessionState {
     internal var isEmpty: Bool { return state.isEmpty }
 
     /// Actual session state
-    private var state: JSON
+    private var state: [String: Any]
 
     /// Store for session state
     private let store: Store
@@ -46,7 +39,7 @@ public class SessionState {
     internal init(id: String, store: Store) {
         self.id = id
         self.store = store
-        state = JSON([String: SessionStateObjectType]() as SessionStateObjectType)
+        state = [String: Any]()
     }
 
     /// Reload the session data from the session `Store`.
@@ -55,11 +48,12 @@ public class SessionState {
     public func reload(callback: @escaping (NSError?) -> Void) {
         store.load(sessionId: id) {(data: Data?, error: NSError?) in
             if  error == nil {
-                if  let data = data {
-                    self.state = JSON(data: data, options: [])
+                if  let data = data,
+                    let state = (try? JSONSerialization.jsonObject(with: data, options: [])) as? [String:Any] {
+                    self.state = state
                 } else {
                     // Not found in store
-                    self.state = JSON([String: SessionStateObjectType]() as SessionStateObjectType)
+                    self.state = [:]
                 }
                 self.isDirty = false
             }
@@ -72,7 +66,7 @@ public class SessionState {
     /// - Parameter callback: The closure to invoke once the writing of session data is complete.
     public func save(callback: @escaping (NSError?) -> Void) {
         do {
-            let data = try state.rawData()
+            let data = try JSONSerialization.data(withJSONObject: self.state, options: [])
             store.save(sessionId: id, data: data, callback: callback)
         } catch {
             #if os(Linux)
@@ -90,7 +84,7 @@ public class SessionState {
     /// - Parameter callback: The closure to invoke once the deletion of session data is complete.
     public func destroy(callback: @escaping (NSError?) -> Void) {
         store.delete(sessionId: id) { error in
-            self.state = JSON([String: SessionStateObjectType]() as SessionStateObjectType)
+            self.state = [:]
             self.isDirty = false
             callback(error)
         }
@@ -107,7 +101,7 @@ public class SessionState {
     /// Retrieve an entry from the session data.
     ///
     /// - Parameter key: The key of the entry to retrieve.
-    public subscript(key: String) -> JSON {
+    public subscript(key: String) -> Any? {
         get {
             return state[key]
         }

--- a/Tests/KituraSessionTests/TestSession.swift
+++ b/Tests/KituraSessionTests/TestSession.swift
@@ -19,7 +19,6 @@ import KituraNet
 
 import Foundation
 import XCTest
-import SwiftyJSON
 
 @testable import KituraSession
 
@@ -39,12 +38,6 @@ class TestSession: XCTestCase, KituraTest {
                    ("testCookieValue", testCookieValue)
         ]
     }
-
-    #if os(Linux)
-        typealias PropValue = Any
-    #else
-        typealias PropValue = AnyObject
-    #endif
 
     func testCookieParams1() {
         let router = setupAdvancedSessionRouter()
@@ -73,7 +66,7 @@ class TestSession: XCTestCase, KituraTest {
         router.all(middleware: Session(secret: "Very very secret.....", cookie: [.name(cookie1Name), .path("/1"), .maxAge(2)]))
 
         router.get("/1/session") {request, response, next in
-            request.session?[sessionTestKey] = JSON(sessionTestValue as PropValue)
+            request.session?[sessionTestKey] = sessionTestValue
             response.status(.noContent)
 
             next()
@@ -196,14 +189,14 @@ class TestSession: XCTestCase, KituraTest {
         router.all(middleware: Session(secret: "Very very secret....."))
 
         router.get("/2/session") {request, response, next in
-            request.session?[sessionTestKey] = JSON(sessionTestValue as PropValue)
+            request.session?[sessionTestKey] = sessionTestValue
             response.status(.noContent)
 
             next()
         }
 
         router.post("/3/session") {request, response, next in
-            request.session?[sessionTestKey] = JSON(sessionTestValue as PropValue)
+            request.session?[sessionTestKey] = sessionTestValue
             response.status(.noContent)
 
             next()
@@ -212,7 +205,7 @@ class TestSession: XCTestCase, KituraTest {
         router.get("/3/session") {request, response, next in
             response.headers.append("Content-Type", value: "text/plain; charset=utf-8")
             do {
-                if let value = request.session?[sessionTestKey].string {
+                if let value = request.session?[sessionTestKey] as? String {
                     try response.status(.OK).send("\(value)").end()
                 } else {
                     response.status(.noContent)


### PR DESCRIPTION
Update Kitura-Session to remove swiftyJSON as a dependency for issue #516. This is a breaking change since the we now store the session as a [String:Any] dictionary meaning when you use the subscript function you will now be returned an Any object instead of a JSON object. 

Corresponding Pull requests for:

Kitura-Credentials
Kitura-Session-Redis
Kitura-CredentialsGitHub
Kitura-CredentialsFacebook
Kitura-CredentialsGoogle

Have also been given which remove their dependancy on swiftyJSON and allow use if the updated Kitura-Session