### PR TITLE
Build against Swift 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,11 @@ matrix:
       dist: trusty
       sudo: required
       services: docker
+      env: DOCKER_IMAGE=ubuntu:16.04 SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
+    - os: linux
+      dist: trusty
+      sudo: required
+      services: docker
       env: DOCKER_IMAGE=ubuntu:18.04
     - os: osx
       osx_image: xcode9.2
@@ -43,6 +48,10 @@ matrix:
     - os: osx
       osx_image: xcode10
       sudo: required
+    - os: osx
+      osx_image: xcode10.1
+      sudo: required
+      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
 
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git

--- a/Sources/KituraSession/RouterRequest+Session.swift
+++ b/Sources/KituraSession/RouterRequest+Session.swift
@@ -23,7 +23,7 @@ private let SESSION_USER_INFO_KEY = "@@Kitura@@Session@@"
 
 /// Extension of the `RouterRequest` class that provides access to the session's state
 /// that is stored in a `SessionState` object.
-public extension RouterRequest {
+extension RouterRequest {
     
     /// The session's state that is stored in a `SessionState` object.
     public internal(set) var session: SessionState? {


### PR DESCRIPTION
Adds testing with a Swift 5 development snapshot. The snapshot is defined in Travis as `SWIFT_DEVELOPMENT_SNAPSHOT` consistently across the IBM-Swift repos, to enable us to automate updating the version.

Resolves a Swift 5 compilation warning relating to a redundant `public` access modifier for members of extensions that have a default declared access level of `public`.