### PR TITLE
fix: Remove Codable sessions for Swift 4.0

### DIFF
--- a/Sources/KituraSession/SessionState.swift
+++ b/Sources/KituraSession/SessionState.swift
@@ -165,4 +165,3 @@ public class SessionState {
 
 
 
-

--- a/Sources/KituraSession/SessionState.swift
+++ b/Sources/KituraSession/SessionState.swift
@@ -116,6 +116,8 @@ public class SessionState {
     /// Retrieve or store a Codable entry from the session data.
     ///
     /// - Parameter key: The Codable key of the entry to retrieve/save.
+    // The swift 4.0 compiler fails to go down the Any subscript route if the object is not Codable so this feature can only be supported on swift 4.1 or higher
+    #if swift(>=4.1)
     public subscript<T: Codable>(key: String) -> T? {
         get {
             guard let value = state[key] else {
@@ -157,7 +159,9 @@ public class SessionState {
             isDirty = true
         }
     }
+    #endif
 }
+
 
 
 

--- a/Tests/KituraSessionTests/TestCodableSession.swift
+++ b/Tests/KituraSessionTests/TestCodableSession.swift
@@ -36,6 +36,7 @@ let CodableSessionTestDict = ["sessionKey1": "sessionValue1", "sessionKey2": "se
 let CodableSessionTestCodableArray = [CodableSessionTest(sessionKey: "sessionValue1"), CodableSessionTest(sessionKey: "sessionValue2"), CodableSessionTest(sessionKey: "sessionValue3")]
 let CodableSessionTestCodableDict = ["sessionKey1": CodableSessionTest(sessionKey: "sessionValue1"), "sessionKey2": CodableSessionTest(sessionKey: "sessionValue2"), "sessionKey3": CodableSessionTest(sessionKey: "sessionValue3")]
 
+#if swift(>=4.1)
 class TestCodableSession: XCTestCase, KituraTest {
     
     static var allTests: [(String, (TestCodableSession) -> () throws -> Void)] {
@@ -250,3 +251,4 @@ class TestCodableSession: XCTestCase, KituraTest {
         })
     }
 }
+#endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -21,4 +21,4 @@ var testcases = [testCase(TestSession.allTests), testCase(TestTypeSafeSession.al
 #if swift(>=4.1)
     testcases.append(TestCodableSession.allTests)
 #endif
-XCTMain([testcases])
+XCTMain(testcases)

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -17,7 +17,7 @@
 import XCTest
 
 @testable import KituraSessionTests
-var testcases = [testCase(TestSession.allTests), testCase(TestTypeSafeSession.allTests]
+var testcases = [testCase(TestSession.allTests), testCase(TestTypeSafeSession.allTests)]
 #if swift(>=4.1)
     testcases.append(TestCodableSession.allTests)
 #endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -19,6 +19,6 @@ import XCTest
 @testable import KituraSessionTests
 var testcases = [testCase(TestSession.allTests), testCase(TestTypeSafeSession.allTests)]
 #if swift(>=4.1)
-    testcases.append(TestCodableSession.allTests)
+    testcases.append(testCase(TestCodableSession.allTests))
 #endif
 XCTMain(testcases)

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -18,9 +18,15 @@ import XCTest
 
 @testable import KituraSessionTests
 
-
+#if swift(>=4.1)
 XCTMain([
             testCase(TestSession.allTests),
             testCase(TestCodableSession.allTests),
             testCase(TestTypeSafeSession.allTests)
     ])
+#else
+XCTMain([
+    testCase(TestSession.allTests),
+    testCase(TestTypeSafeSession.allTests)
+    ])
+#endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -17,16 +17,8 @@
 import XCTest
 
 @testable import KituraSessionTests
-
+var testcases = [testCase(TestSession.allTests), testCase(TestTypeSafeSession.allTests]
 #if swift(>=4.1)
-XCTMain([
-            testCase(TestSession.allTests),
-            testCase(TestCodableSession.allTests),
-            testCase(TestTypeSafeSession.allTests)
-    ])
-#else
-XCTMain([
-    testCase(TestSession.allTests),
-    testCase(TestTypeSafeSession.allTests)
-    ])
+    testcases.append(TestCodableSession.allTests)
 #endif
+XCTMain([testcases])


### PR DESCRIPTION
This pull request removes the Codable Session feature for Swift 4.0. This is because the Swift 4.0 compiler doesn't go down the Any subscript path when a complex object is not codable. This can cause existing code to break which caused a [test failure](https://github.com/IBM-Swift/Kitura-Credentials/issues/77) in credentials.