### PR TITLE
fix: Use PKCS7 padding for cookie cryptor

### DIFF
--- a/Sources/KituraSession/CookieCryptography.swift
+++ b/Sources/KituraSession/CookieCryptography.swift
@@ -35,11 +35,6 @@ class CookieCryptography {
     ///
     private var signatureKey: [UInt8]
 
-    ///
-    /// Length of cookie value before padding
-    ///
-    private let originalLength = 36
-
     init (secret: String) throws {
         let encryptionKeySalt = "If two witches would watch two watches, which witch would watch which watch?"
         let signatureKeySalt = "Six sick hicks nick six slick bricks with picks and sticks."


### PR DESCRIPTION
This PR is In response to issue #61. 
In cookie cryptor, we were ecrypting the session Id using aes with our own implementation of padding where we would add 0x00 until it was the correct block size. Then when decrypting we would only take the first 36 bytes. This will only give us our original plaintext back if the input was 36 bytes long (The size of a UUID). 
This was working since we consistently used the shortened data however this is fragile and if an input of less than 16 bytes was used then it would crash on trying to decrypt.

This PR changes our encode and decode to use BlueCryptor PKCS7 padding so that we can encrypt and decrypt and length and the original plaintext will be returned.