### PR TITLE
Add test for invalid session

### DIFF
--- a/Tests/KituraSessionTests/TestSession.swift
+++ b/Tests/KituraSessionTests/TestSession.swift
@@ -36,6 +36,7 @@ class TestSession: XCTestCase, KituraTest {
                    ("testSimpleSession", testSimpleSession),
                    ("testCookieName", testCookieName),
                    ("testCookieValue", testCookieValue),
+                   ("testInvalidCookie", testInvalidCookie),
         ]
     }
 
@@ -172,6 +173,15 @@ class TestSession: XCTestCase, KituraTest {
         })
     }
 
+    func testInvalidCookie() {
+        let router = setupBasicSessionRouter()
+        performServerTest(router: router, asyncTasks: {
+            self.performRequest(method: "get", path: "/3/session", callback: {response in
+
+            }, headers: ["Cookie": "\(cookieDefaultName)=!.!.!"])
+        })
+    }
+    
     func setupBasicSessionRouter() -> Router {
         let router = Router()
 

--- a/Tests/KituraSessionTests/TestSession.swift
+++ b/Tests/KituraSessionTests/TestSession.swift
@@ -176,8 +176,11 @@ class TestSession: XCTestCase, KituraTest {
     func testInvalidCookie() {
         let router = setupBasicSessionRouter()
         performServerTest(router: router, asyncTasks: {
-            self.performRequest(method: "get", path: "/3/session", callback: {response in
-
+            self.performRequest(method: "get", path: "/3/session", callback: { response in
+				guard let response = response else {
+					return
+				}
+				XCTAssertEqual(response.statusCode, HTTPStatusCode.noContent)
             }, headers: ["Cookie": "\(cookieDefaultName)=!.!.!"])
         })
     }

--- a/Tests/KituraSessionTests/TestSession.swift
+++ b/Tests/KituraSessionTests/TestSession.swift
@@ -177,10 +177,10 @@ class TestSession: XCTestCase, KituraTest {
         let router = setupBasicSessionRouter()
         performServerTest(router: router, asyncTasks: {
             self.performRequest(method: "get", path: "/3/session", callback: { response in
-				guard let response = response else {
-					return
-				}
-				XCTAssertEqual(response.statusCode, HTTPStatusCode.noContent)
+                guard let response = response else {
+                    return
+                }
+                XCTAssertEqual(response.statusCode, HTTPStatusCode.noContent)
             }, headers: ["Cookie": "\(cookieDefaultName)=!.!.!"])
         })
     }


### PR DESCRIPTION
Kitura-Session used to crash if you provided an invalid cookie to BlueCryptor. 
This has been fix with BlueCryptor 1.0.26 meaning this added test will now succeed.