### PR TITLE
Import FoundationNetworking for Swift 5.1

### DIFF
--- a/Sources/KituraSession/CookieManagement.swift
+++ b/Sources/KituraSession/CookieManagement.swift
@@ -18,6 +18,11 @@ import Kitura
 import LoggerAPI
 
 import Foundation
+#if swift(>=4.1)
+  #if canImport(FoundationNetworking)
+    import FoundationNetworking
+  #endif
+#endif
 
 internal class CookieManagement {
 

--- a/Tests/KituraSessionTests/CookieUtils.swift
+++ b/Tests/KituraSessionTests/CookieUtils.swift
@@ -18,6 +18,11 @@
 import KituraNet
 import Foundation
 import XCTest
+#if swift(>=4.1)
+  #if canImport(FoundationNetworking)
+    import FoundationNetworking
+  #endif
+#endif
 
 class CookieUtils {
 


### PR DESCRIPTION
Resolve compilation errors and warnings relating to changes in the Swift 5.1 release:
- `import FoundationNetworking` on Linux to access `HTTPCookie` and similar types, due to [changes to Foundation structure](https://forums.swift.org/t/foundationnetworking/24769)
- fix compilation warnings relating to `var`s that were never mutated